### PR TITLE
Make use of the export interval flag in the sample

### DIFF
--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -6,7 +6,7 @@
     <Company>Dynatrace</Company>
     <Product>Dynatrace OpenTelemetry Metrics Exporter for .NET</Product>
     <PackageId>Dynatrace.OpenTelemetry.Exporter.Metrics</PackageId>
-    <Version>0.3.0-beta</Version>
+    <Version>0.3.1-beta</Version>
     <Description>See https://github.com/dynatrace-oss/opentelemetry-metric-dotnet to learn more.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2020 Dynatrace LLC; Licensed under the Apache License, Version 2.0</Copyright>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/DynatraceMetricsExporter.cs
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/DynatraceMetricsExporter.cs
@@ -95,6 +95,7 @@ namespace Dynatrace.OpenTelemetry.Exporter.Metrics
 						var response = _httpClient.SendAsync(httpRequest).GetAwaiter().GetResult();
 						if (response.IsSuccessStatusCode)
 						{
+							_logger.SuccessRequestResult(response.StatusCode);
 							exportResult = ExportResult.Success;
 						}
 						else

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/LoggerExtensions.cs
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/LoggerExtensions.cs
@@ -55,6 +55,10 @@ namespace Dynatrace.OpenTelemetry.Exporter.Metrics
 			LoggerMessage.Define<string>(LogLevel.Warning, new EventId(7, nameof(ReceivedCumulativeValue)),
 				"Received metric: '{MetricName}' with cumulative aggregation temporality. Exporting as gauge");
 
+		private static readonly Action<ILogger, HttpStatusCode, Exception> _successRequestResult =
+			LoggerMessage.Define<HttpStatusCode>(LogLevel.Debug, new EventId(8, nameof(SuccessRequestResult)),
+				"Exporting metrics succeed: StatusCode: {StatusCode}");
+
 		internal static void DynatraceMetricUrl(this ILogger logger, string url)
 			=> _dynatraceMetricUrl(logger, url, null);
 
@@ -75,5 +79,8 @@ namespace Dynatrace.OpenTelemetry.Exporter.Metrics
 
 		internal static void ReceivedCumulativeValue(this ILogger logger, string metricName)
 			=> _receivedCumulativeValue(logger, metricName, null);
+
+		internal static void SuccessRequestResult(this ILogger logger, HttpStatusCode statusCode)
+			=> _successRequestResult(logger, statusCode, null);
 	}
 }

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/LoggerExtensions.cs
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/LoggerExtensions.cs
@@ -57,7 +57,7 @@ namespace Dynatrace.OpenTelemetry.Exporter.Metrics
 
 		private static readonly Action<ILogger, HttpStatusCode, Exception> _successRequestResult =
 			LoggerMessage.Define<HttpStatusCode>(LogLevel.Debug, new EventId(8, nameof(SuccessRequestResult)),
-				"Exporting metrics succeed: StatusCode: {StatusCode}");
+				"Exporting metrics succeeded: StatusCode: {StatusCode}");
 
 		internal static void DynatraceMetricUrl(this ILogger logger, string url)
 			=> _dynatraceMetricUrl(logger, url, null);

--- a/src/Examples.Console/DynatraceExporterExample.cs
+++ b/src/Examples.Console/DynatraceExporterExample.cs
@@ -58,6 +58,7 @@ namespace Examples.Console
 					cfg.EnrichWithDynatraceMetadata = runOptions.EnableDynatraceMetadataEnrichment;
 					cfg.DefaultDimensions = new Dictionary<string, string> { { "default1", "defval1" } };
 					cfg.Prefix = "otel.dotnet";
+					cfg.MetricExportIntervalMilliseconds = runOptions.ExportIntervalMilliseconds;
 
 					if (runOptions.Url != null)
 					{

--- a/src/Examples.Console/Program.cs
+++ b/src/Examples.Console/Program.cs
@@ -35,7 +35,7 @@ namespace Examples.Console
 	[Verb("dynatrace", HelpText = "Specify the options required to test Dynatrace")]
 	internal class Options
 	{
-		[Option('i', "exportIntervalMillis", Default = 1000, HelpText = "The interval at which metrics are exported to Dynatrace.", Required = false)]
+		[Option('i', "exportIntervalMillis", Default = 5000, HelpText = "The interval at which metrics are exported to Dynatrace.", Required = false)]
 		public int ExportIntervalMilliseconds { get; set; }
 
 		[Option('d', "durationMins", Default = 2, HelpText = "Total duration in minutes to run the demo. Run at least for one minute to see metrics flowing.", Required = false)]


### PR DESCRIPTION
- [x] Make sure to use the flag `--exportIntervalMillis` when configuring the `DynatraceMetricsExporter`
- [x] Make sure the flag has a default value set (5 seconds)
- [x] Added a debug log for success export HTTP requests
- [x] Bump version (introduced a new debug log)