### PR TITLE
Use new DateTimeOffset API

### DIFF
--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -6,7 +6,7 @@
     <Company>Dynatrace</Company>
     <Product>Dynatrace OpenTelemetry Metrics Exporter for .NET</Product>
     <PackageId>Dynatrace.OpenTelemetry.Exporter.Metrics</PackageId>
-    <Version>0.3.1-beta</Version>
+    <Version>0.3.2-beta</Version>
     <Description>See https://github.com/dynatrace-oss/opentelemetry-metric-dotnet to learn more.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2020 Dynatrace LLC; Licensed under the Apache License, Version 2.0</Copyright>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.2.0-beta2.1" />
-    <PackageReference Include="Dynatrace.MetricUtils" Version="0.1.0-beta" />
+    <PackageReference Include="Dynatrace.MetricUtils" Version="0.2.0-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/DynatraceMetricsExtensions.cs
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/DynatraceMetricsExtensions.cs
@@ -29,28 +29,28 @@ namespace Dynatrace.OpenTelemetry.Exporter.Metrics
 				metric.Name,
 				metricPoint.LongValue,
 				metricPoint.GetAttributes(logger),
-				metricPoint.EndTime.UtcDateTime);
+				metricPoint.EndTime);
 
 		public static DynatraceMetric ToDoubleCounterDelta(this Metric metric, MetricPoint metricPoint, ILogger logger)
 			=> DynatraceMetricsFactory.CreateDoubleCounterDelta(
 				metric.Name,
 				metricPoint.DoubleValue,
 				metricPoint.GetAttributes(logger),
-				metricPoint.EndTime.UtcDateTime);
+				metricPoint.EndTime);
 
 		public static DynatraceMetric ToLongGauge(this Metric metric, MetricPoint metricPoint, ILogger logger)
 			=> DynatraceMetricsFactory.CreateLongGauge(
 				metric.Name,
 				metricPoint.LongValue,
 				metricPoint.GetAttributes(logger),
-				metricPoint.EndTime.UtcDateTime);
+				metricPoint.EndTime);
 
 		public static DynatraceMetric ToDoubleGauge(this Metric metric, MetricPoint metricPoint, ILogger logger)
 			=> DynatraceMetricsFactory.CreateDoubleGauge(
 				metric.Name,
 				metricPoint.DoubleValue,
 				metricPoint.GetAttributes(logger),
-				metricPoint.EndTime.UtcDateTime);
+				metricPoint.EndTime);
 
 		public static DynatraceMetric ToDoubleHistogram(this Metric metric, MetricPoint metricPoint, ILogger logger)
 		{
@@ -64,7 +64,7 @@ namespace Dynatrace.OpenTelemetry.Exporter.Metrics
 				metricPoint.DoubleValue,
 				metricPoint.LongValue,
 				metricPoint.GetAttributes(logger),
-				metricPoint.EndTime.UtcDateTime);
+				metricPoint.EndTime);
 		}
 
 		private static double GetMinFromBoundaries(MetricPoint pointData)


### PR DESCRIPTION
Update to the latest version of the Utils package to use the simpler API. 

Note: Build will fail because the new version is not published yet: https://github.com/dynatrace-oss/dynatrace-metric-utils-dotnet/pull/3