### PR TITLE
Prepare 1.0.0 release

### DIFF
--- a/.github/workflows/dotnet-core-build-test.yml
+++ b/.github/workflows/dotnet-core-build-test.yml
@@ -2,7 +2,7 @@ name: .NET Core Build and Test
 
 on:
   push:
-  #    branches: [ main ]
+      branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/dotnet-core-build-test.yml
+++ b/.github/workflows/dotnet-core-build-test.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
-          - macos-latest
+#          - windows-latest
+#          - macos-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/dotnet-core-build-test.yml
+++ b/.github/workflows/dotnet-core-build-test.yml
@@ -2,37 +2,48 @@ name: .NET Core Build and Test
 
 on:
   push:
-    branches: [ main ]
+  #    branches: [ main ]
   pull_request:
     branches: [ main ]
 
 jobs:
-  build:
+  build-test:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+      - name: Setup dotnet (multiple versions)
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            3.1.x
+            6.0.x
 
-    - name: Install dependencies
-      run: dotnet restore
+      - name: Install dependencies
+        run: dotnet restore
 
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
 
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal
 
-    - name: Package
-      run: dotnet pack src/Dynatrace.OpenTelemetry.Exporter.Metrics --configuration Release --no-build
+      # packaging and uploading the nupkg, it should be enough to build this on one OS, it can be used for all OSes
+      - name: Package
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: dotnet pack src/Dynatrace.OpenTelemetry.Exporter.Metrics --configuration Release --no-build
 
-    - name: Archive nupkg
-      uses: actions/upload-artifact@v2
-      with:
-        name: nupkg
-        path: '**/bin/**/*.*nupkg'
+      - name: Archive nupkg
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: nupkg
+          path: '**/bin/**/*.*nupkg'

--- a/.github/workflows/dotnet-core-build-test.yml
+++ b/.github/workflows/dotnet-core-build-test.yml
@@ -12,19 +12,18 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - windows-latest
-#          - macos-latest
+          - windows-latest
+          - macos-latest
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup dotnet (multiple versions)
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            3.1.x
             6.0.x
 
       - name: Install dependencies

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0,netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-		<PackageReference Include="Moq" Version="4.16.1" />
+		<PackageReference Include="Moq" Version="4.18.1" />
 		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0" />
 		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.2.0-rc5" />
 		<PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net6.0,netcoreapp3.1</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.2.0" />
-    <PackageReference Include="Dynatrace.MetricUtils" Version="0.2.0-beta" />
+    <PackageReference Include="Dynatrace.MetricUtils" Version="0.3.0-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.2.0" />
-    <PackageReference Include="Dynatrace.MetricUtils" Version="0.2.0-beta" />
+    <PackageReference Include="Dynatrace.MetricUtils" Version="0.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -6,7 +6,7 @@
     <Company>Dynatrace</Company>
     <Product>Dynatrace OpenTelemetry Metrics Exporter for .NET</Product>
     <PackageId>Dynatrace.OpenTelemetry.Exporter.Metrics</PackageId>
-    <Version>0.5.0</Version>
+    <Version>1.0.0</Version>
     <Description>See https://github.com/dynatrace-oss/opentelemetry-metric-dotnet to learn more.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2020 Dynatrace LLC; Licensed under the Apache License, Version 2.0</Copyright>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.2.0" />
-    <PackageReference Include="Dynatrace.MetricUtils" Version="0.3.0-beta" />
+    <PackageReference Include="Dynatrace.MetricUtils" Version="0.2.0-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples.Console/Examples.Console.csproj
+++ b/src/Examples.Console/Examples.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Update target .NET Frameworks
* Update GH action to run on all OSes
* Use non-beta version of the Utils lib (0.3.0)
* Bump exporter version to 1.0.0 (🎉)
 