### PR TITLE
Try exporter with latest version of OTel .NET SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ directly to [Dynatrace](https://www.dynatrace.com).
 More information on exporting OpenTelemetry metrics to Dynatrace can be found in the
 [Dynatrace documentation](https://www.dynatrace.com/support/help/extend-dynatrace/opentelemetry/opentelemetry-metrics).
 
-This exporter is built against the OpenTelemetry .NET
-SDK [v1.2.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.2.0) which is the first stable
-release for the metrics SDK and should be compatible with this and later versions.
+This exporter is built against the OpenTelemetry .NET SDK [v1.3.2](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.2). It should be compatible with applications targeting OpenTelemetry .NET SDK version 1.2.0 and higher.
 
 ## Getting started
 
-The general setup of OpenTelemetry .NET is explained in the official [Getting Started Guide](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.2.0/docs/metrics/getting-started/README.md).
+The general setup of OpenTelemetry .NET is explained in the official [Getting Started Guide](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.3.2/docs/metrics/getting-started/README.md).
 
 To add the exporter to your project, install the [Dynatrace.OpenTelemetry.Exporter.Metrics](https://www.nuget.org/packages/Dynatrace.OpenTelemetry.Exporter.Metrics) package to your project.
 This can be done through the NuGet package manager in Visual Studio or by running the following command in your project folder:
@@ -28,6 +26,12 @@ This exporter package targets [.NET Standard 2.0](https://docs.microsoft.com/en-
 To set up a Dynatrace metrics exporter, add the following code to your project:
 
 ```csharp
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using Dynatrace.OpenTelemetry.Exporter.Metrics;
+
 // A Meter instance is obtained via the System.Diagnostics.DiagnosticSource package
 var meter = new Meter("my_meter", "0.0.1");
 
@@ -59,6 +63,13 @@ and it is recommended to restrict the token access to that scope.
 More information about the token setup can be found [here](#dynatrace-api-token).
 
 ```csharp
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using Dynatrace.OpenTelemetry.Exporter.Metrics;
+
 // Not required, but potentially helpful.
 // The exporter logs information about preparing and exporting metrics.
 var loggerFactory = LoggerFactory.Create(builder =>
@@ -96,6 +107,13 @@ configured in the `DynatraceExporterOptions`.
 Read the [Configuration section](#configuration) to learn more about each of them.
 
 ```csharp
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using Dynatrace.OpenTelemetry.Exporter.Metrics;
+
 using var provider = Sdk.CreateMeterProviderBuilder()
     .AddMeter(meter.Name)
     .AddDynatraceExporter(cfg =>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ directly to [Dynatrace](https://www.dynatrace.com).
 More information on exporting OpenTelemetry metrics to Dynatrace can be found in the
 [Dynatrace documentation](https://www.dynatrace.com/support/help/extend-dynatrace/opentelemetry/opentelemetry-metrics).
 
-This exporter is built against the OpenTelemetry .NET SDK [v1.3.2](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.2). It should be compatible with applications targeting OpenTelemetry .NET SDK version 1.2.0 and higher.
+This exporter is built against the OpenTelemetry .NET SDK [v1.3.2](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.2).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ directly to [Dynatrace](https://www.dynatrace.com).
 More information on exporting OpenTelemetry metrics to Dynatrace can be found in the
 [Dynatrace documentation](https://www.dynatrace.com/support/help/extend-dynatrace/opentelemetry/opentelemetry-metrics).
 
-This exporter is built against the OpenTelemetry .NET SDK [v1.3.2](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.2).
+This exporter is built against the OpenTelemetry .NET SDK
+[v1.2.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.2.0).
+It should be compatible with applications targeting OpenTelemetry .NET SDK version 1.2.0 and higher.
+
+> It is highly recommended to update the OpenTelemetry .NET SDK in your applications to version `1.3.1` or later
+> to avoid being impacted by this issue:
+> [Possible app crash for OpenTelemetry .NET versions 1.3.0 and prior](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3629)
 
 ## Getting started
 
@@ -19,7 +25,7 @@ This can be done through the NuGet package manager in Visual Studio or by runnin
 dotnet add package Dynatrace.OpenTelemetry.Exporter.Metrics
 ```
 
-This exporter package targets [.NET Standard 2.0](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) and can therefore be included on .NET Core 2.0 and above, as well as .NET Framework 4.6.1 and above.
+This exporter package targets [.NET Standard 2.0](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) and can therefore be included on .NET Core 2.0 and above, as well as .NET Framework 4.6.2 and above.
 
 ### Setup
 

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
@@ -9,8 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="Moq" Version="4.18.1" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.2.0-rc5" />
+		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.3.2" />
 		<PackageReference Include="xunit" Version="2.4.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
 		<PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/DynatraceMetricsExporterTests.cs
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/DynatraceMetricsExporterTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -726,6 +727,68 @@ counterB,attr1=v1,attr2=v2,dt.metrics.source=opentelemetry count,delta=20 {point
 				ItExpr.IsAny<CancellationToken>());
 
 			AssertExportRequest(actualRequestMessage);
+		}
+
+		[Theory]
+		[InlineData("en-US")]
+		[InlineData("en-GB")]
+		[InlineData("pt-BR")]
+		[InlineData("de-AT")]
+		[InlineData("fi-FI")]
+		public async Task TestAllInstrumentsWithCulture(string locale)
+		{
+			var originalCulture = Thread.CurrentThread.CurrentCulture;
+			Thread.CurrentThread.CurrentCulture = new CultureInfo(locale);
+
+			// Arrange
+			HttpRequestMessage actualRequestMessage = null!;
+			var mockMessageHandler = SetupHttpMock(r => actualRequestMessage = r);
+
+			var sut = new DynatraceMetricsExporter(null, null, new HttpClient(mockMessageHandler.Object));
+
+			var longCounter = _meter.CreateCounter<long>("counter");
+			longCounter.Add(10);
+
+			var doubleCounter = _meter.CreateCounter<double>("double_counter");
+			doubleCounter.Add(10.3);
+
+			_meter.CreateObservableCounter("obs_counter",
+				() => new List<Measurement<long>> { new(1 * 10) });
+
+			var i = 1;
+			_meter.CreateObservableCounter("double_obs_counter",
+				() => new List<Measurement<double>> { new(1 * 10.3, _attributes) });
+
+			var longHistogram = _meter.CreateHistogram<long>("histogram");
+			longHistogram.Record(1);
+			longHistogram.Record(6);
+			longHistogram.Record(11);
+			longHistogram.Record(21);
+
+			var doubleHistogram = _meter.CreateHistogram<double>("double_histogram");
+			doubleHistogram.Record(1.1);
+			doubleHistogram.Record(6.2);
+			doubleHistogram.Record(11.3);
+			doubleHistogram.Record(21.23);
+
+			// Act
+			_meterProvider.ForceFlush();
+			sut.Export(new Batch<Metric>(_exportedMetrics.ToArray(), _exportedMetrics.Count));
+
+			// Assert
+			var point = MetricTest.FromMetricPoints(_exportedMetrics.First().GetMetricPoints()).First();
+
+			var expected = @$"counter,dt.metrics.source=opentelemetry count,delta=10 {point.TimeStamp}
+double_counter,dt.metrics.source=opentelemetry count,delta=10.3 {point.TimeStamp}
+obs_counter,dt.metrics.source=opentelemetry count,delta=10 {point.TimeStamp}
+double_obs_counter,attr1=v1,attr2=v2,dt.metrics.source=opentelemetry count,delta=10.3 {point.TimeStamp}
+histogram,dt.metrics.source=opentelemetry gauge,min=0,max=25,sum=39,count=4 {point.TimeStamp}
+double_histogram,dt.metrics.source=opentelemetry gauge,min=0,max=25,sum=39.83,count=4 {point.TimeStamp}";
+
+			var actualMetricString = await actualRequestMessage.Content!.ReadAsStringAsync();
+			Assert.Equal(expected, actualMetricString);
+
+			Thread.CurrentThread.CurrentCulture = originalCulture;
 		}
 
 		private static Mock<HttpMessageHandler> SetupHttpMock(

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/DynatraceMetricsExporterTests.cs
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/DynatraceMetricsExporterTests.cs
@@ -755,7 +755,6 @@ counterB,attr1=v1,attr2=v2,dt.metrics.source=opentelemetry count,delta=20 {point
 			_meter.CreateObservableCounter("obs_counter",
 				() => new List<Measurement<long>> { new(1 * 10) });
 
-			var i = 1;
 			_meter.CreateObservableCounter("double_obs_counter",
 				() => new List<Measurement<double>> { new(1 * 10.3, _attributes) });
 

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -6,7 +6,7 @@
     <Company>Dynatrace</Company>
     <Product>Dynatrace OpenTelemetry Metrics Exporter for .NET</Product>
     <PackageId>Dynatrace.OpenTelemetry.Exporter.Metrics</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Description>See https://github.com/dynatrace-oss/opentelemetry-metric-dotnet to learn more.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2020 Dynatrace LLC; Licensed under the Apache License, Version 2.0</Copyright>
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.2.0" />
-    <PackageReference Include="Dynatrace.MetricUtils" Version="0.3.0" />
+    <PackageReference Include="Dynatrace.MetricUtils" Version="0.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.2" />
     <PackageReference Include="Dynatrace.MetricUtils" Version="0.3.0" />
   </ItemGroup>
 

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -6,7 +6,7 @@
     <Company>Dynatrace</Company>
     <Product>Dynatrace OpenTelemetry Metrics Exporter for .NET</Product>
     <PackageId>Dynatrace.OpenTelemetry.Exporter.Metrics</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Description>See https://github.com/dynatrace-oss/opentelemetry-metric-dotnet to learn more.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2020 Dynatrace LLC; Licensed under the Apache License, Version 2.0</Copyright>

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj
@@ -6,7 +6,7 @@
     <Company>Dynatrace</Company>
     <Product>Dynatrace OpenTelemetry Metrics Exporter for .NET</Product>
     <PackageId>Dynatrace.OpenTelemetry.Exporter.Metrics</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.0.0</Version>
     <Description>See https://github.com/dynatrace-oss/opentelemetry-metric-dotnet to learn more.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2020 Dynatrace LLC; Licensed under the Apache License, Version 2.0</Copyright>
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.3.2" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="Dynatrace.MetricUtils" Version="0.3.0" />
   </ItemGroup>
 

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics/DynatraceMetricsExporterExtensions.cs
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics/DynatraceMetricsExporterExtensions.cs
@@ -62,8 +62,10 @@ namespace Dynatrace.OpenTelemetry.Exporter.Metrics
 			}
 
 			var metricExporter = new DynatraceMetricsExporter(options, logger);
-			var metricReader = new PeriodicExportingMetricReader(metricExporter, options.MetricExportIntervalMilliseconds);
-			metricReader.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+			var metricReader = new PeriodicExportingMetricReader(metricExporter, options.MetricExportIntervalMilliseconds)
+			{
+				TemporalityPreference = MetricReaderTemporalityPreference.Delta
+			};
 			return builder.AddReader(metricReader);
 		}
 	}

--- a/src/Examples.Console/Examples.Console.csproj
+++ b/src/Examples.Console/Examples.Console.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.3.2" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
   </ItemGroup>


### PR DESCRIPTION
- Bump the version of the Utils to address issue with numbers being serialized with wrong culture
- Add note recomending users to update to OTel SDK `1.3.1` or higher to avoid the bug found in the SDK
- Update sample/tests to use SDK/Exporter version `1.3.2`
- Some small improvements in the README
- Verified that the included samples work when the app uses a higher version of the OTel SDK (`1.3.2`) than what is shipped with our library (`1.2.0`)