### PR TITLE
Try exporter with latest version of OTel .NET SDK (1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It should be compatible with applications targeting OpenTelemetry .NET SDK versi
 
 ## Getting started
 
-The general setup of OpenTelemetry .NET is explained in the official [Getting Started Guide](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.3.2/docs/metrics/getting-started/README.md).
+The general setup of OpenTelemetry .NET is explained in the official [Getting Started Guide](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.4.0/docs/metrics/getting-started/README.md).
 
 To add the exporter to your project, install the [Dynatrace.OpenTelemetry.Exporter.Metrics](https://www.nuget.org/packages/Dynatrace.OpenTelemetry.Exporter.Metrics) package to your project.
 This can be done through the NuGet package manager in Visual Studio or by running the following command in your project folder:

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="Moq" Version="4.18.1" />
-		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.3.2" />
+		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.4.0" />
 		<PackageReference Include="xunit" Version="2.4.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
 		<PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/DynatraceMetricsExporterTests.cs
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/DynatraceMetricsExporterTests.cs
@@ -56,7 +56,7 @@ namespace Dynatrace.OpenTelemetry.Exporter.Metrics.Tests
 		public void Dispose()
 		{
 			_meter.Dispose();
-			_meterProvider?.Dispose();
+			_meterProvider.Dispose();
 		}
 
 		[Fact]

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/DynatraceMetricsExporterTests.cs
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/DynatraceMetricsExporterTests.cs
@@ -50,13 +50,13 @@ namespace Dynatrace.OpenTelemetry.Exporter.Metrics.Tests
 				.AddMeter(_meter.Name)
 				.AddInMemoryExporter(_exportedMetrics,
 					options => options.TemporalityPreference = MetricReaderTemporalityPreference.Delta)
-				.Build();
+				.Build()!;
 		}
 
 		public void Dispose()
 		{
 			_meter.Dispose();
-			_meterProvider.Dispose();
+			_meterProvider?.Dispose();
 		}
 
 		[Fact]

--- a/src/Examples.Console/Examples.Console.csproj
+++ b/src/Examples.Console/Examples.Console.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.3.2" />
+    <PackageReference Include="OpenTelemetry" Version="1.4.0" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
   </ItemGroup>


### PR DESCRIPTION
- Update sample/tests to use SDK/Exporter version `1.4.0`
- Verified that the included samples work when the app uses a higher version of the OTel SDK (`1.4.0`) than what is shipped with our library (`1.2.0`)