### PR TITLE
chore: bump otel version to 1.6.0 in example/test/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It should be compatible with applications targeting OpenTelemetry .NET SDK versi
 
 ### Getting started
 
-The general setup of OpenTelemetry .NET is explained in the official [Getting Started Guide](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.5.1/docs/metrics/getting-started-console/README.md).
+The general setup of OpenTelemetry .NET is explained in the official [Getting Started Guide](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.6.0/docs/metrics/getting-started-console/README.md).
 
 To add the exporter to your project, install the [Dynatrace.OpenTelemetry.Exporter.Metrics](https://www.nuget.org/packages/Dynatrace.OpenTelemetry.Exporter.Metrics) package to your project.
 This can be done through the NuGet package manager in Visual Studio or by running the following command in your project folder:

--- a/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
+++ b/src/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests/Dynatrace.OpenTelemetry.Exporter.Metrics.Tests.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="Moq" Version="4.18.1" />
-		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.5.1" />
+		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.6.0" />
 		<PackageReference Include="xunit" Version="2.4.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
 		<PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/src/Examples.Console/Examples.Console.csproj
+++ b/src/Examples.Console/Examples.Console.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
   </ItemGroup>


### PR DESCRIPTION
Tested example locally and ran unit tests in CI.